### PR TITLE
Changing the USB PID, VID, and device version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # pico_scpi_usbtmc_lablib
 PSL: framework for SCPI USBTMD compatible lab devices
 
-this repository has a submodule.
-when checking it out, use:  
+This repository has a submodule.
+When checking it out, use:
+
+```shell
 git clone https://github.com/jancumps/pico_scpi_usbtmc_lablib.git --recurse-submodules  
+```
 
 See [Pico SCPI labTool](https://github.com/jancumps/pico_scpi_usbtmc_labtool) for an example firmware project

--- a/usb/usb_descriptors_common.c
+++ b/usb/usb_descriptors_common.c
@@ -47,7 +47,22 @@
 #define USB_PID           (0x41C0 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
                            _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
 
-#define USB_BCD   0x0200
+/* USB device version number (BCD)
+ * 
+ * It's a bit unfortunate that the USB device version is set here,
+ * because this is supposed to be a library usable by various applications.
+ * It would be better if they each set their own USB device version.
+ * However, in practice there's just the one consumer, pico_scpi_usbtmc_labtool.
+ * So it makes sense to use that version number here.
+ * 
+ * I was unable to find a version code for pico_scpi_usbtmc_labtool or pico_scpi_usbtmc_lablib in the code files.
+ * The current release on GitHub is `v0.6.2`, but the document that comes up says `Release 7.1`
+ * My best guess is that the current version and the git tag started at v0.6.2,
+ * but have been further developed and is now at v0.7.1.
+ * 
+ * Therefore, I'm setting the USB device version at 0.71
+ */
+#define USB_DEV   0x0071
 
 //--------------------------------------------------------------------+
 // Device Descriptors
@@ -65,7 +80,7 @@ tusb_desc_device_t const desc_device =
 
     .idVendor           = USB_VID,
     .idProduct          = USB_PID,
-    .bcdDevice          = USB_BCD,
+    .bcdDevice          = USB_DEV,
 
     .iManufacturer      = 0x01,
     .iProduct           = 0x02,

--- a/usb/usb_descriptors_common.c
+++ b/usb/usb_descriptors_common.c
@@ -27,17 +27,26 @@
 #include "class/usbtmc/usbtmc.h"
 #include "usb/usbtmc_device_custom.h"
 
-/* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
+/* 
+ * The owner of VID=0x1209 has generously allowed open-source projects to use their VID code.
+ * See https://pid.codes/1209/
+ */
+#define USB_VID   0x1209
+
+/* 
+ * A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
  * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
  *
  * Auto ProductID layout's Bitmap:
  *   [MSB]         HID | MSC | CDC          [LSB]
+ * 
+ * This project is not formally recognized by pid.codes (see https://pid.codes/howto/),
+ * but it looks like PID=0x41C0 is available and is shaped like the word PICO, which is fun.
  */
 #define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
-#define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
+#define USB_PID           (0x41C0 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
                            _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
 
-#define USB_VID   0xCafe
 #define USB_BCD   0x0200
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
[36973e8](https://github.com/michaelstoops/pico_scpi_usbtmc_lablib/pull/1/commits/36973e82ee9b6f56f92ae908003b14fc31bb3cc9) and [dde8cf9](https://github.com/michaelstoops/pico_scpi_usbtmc_lablib/pull/1/commits/dde8cf9cb76bec9e3c1af0f1b0d40f93b60f821c) address  https://github.com/jancumps/pico_scpi_usbtmc_lablib/issues/5.

[418f4ef](https://github.com/michaelstoops/pico_scpi_usbtmc_lablib/pull/1/commits/418f4ef8b1947d81079e401b028a556906608314) is just a little formatting change.